### PR TITLE
Ignore minified files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,9 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Minified files
+site.min.*
+
+# VS Code
+.vscode/

--- a/swlsimNET/swlsimNET.csproj
+++ b/swlsimNET/swlsimNET.csproj
@@ -1,34 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <WarningsAsErrors>NU1605</WarningsAsErrors>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Data\**" />
     <Content Remove="Data\**" />
     <EmbeddedResource Remove="Data\**" />
     <None Remove="Data\**" />
   </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
     <PackageReference Include="Expressions" Version="0.1.3" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Views\Shared\" />
     <Folder Include="wwwroot\css\" />
     <Folder Include="wwwroot\images\" />
   </ItemGroup>
-
 </Project>

--- a/swlsimNET/wwwroot/css/site.min.css
+++ b/swlsimNET/wwwroot/css/site.min.css
@@ -1,1 +1,0 @@
-body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}.carousel-caption p{font-size:20px;line-height:1.4}.carousel-inner .item img[src$=".svg"]{width:100%}#qrCode{margin:15px}@media screen and (max-width:767px){.carousel-caption{display:none}}


### PR DESCRIPTION
Adds a reference to BuildBundlerMinifier to minify the site CSS and JavaScript during build so that these can be omitted from version control.

This makes the repository cleaner.