### PR TITLE
Fix missing color in Result views PieChart (#63)

### DIFF
--- a/swlSimulator/ClientApp/app/components/result.component.ts
+++ b/swlSimulator/ClientApp/app/components/result.component.ts
@@ -37,15 +37,18 @@ export class ResultComponent implements OnInit {
     ];
 
     public bgcolors: Array<any> = [
-        "#c44224",
-        "#3e95cd",
-        "#c45850",
-        "#3e95cd",
-        "#c45850",
-        "#90A4AE",
-        "#B0BEC5",
-        "#CFD8DC",
-        "#ECEFF1"
+        {
+            backgroundColor: [
+                "#c44224",
+                "#3e95cd",
+                "#c45850",
+                "#3e95cd",
+                "#c45850",
+                "#90A4AE",
+                "#B0BEC5",
+                "#CFD8DC",
+                "#ECEFF1"]
+        }
     ];
     public lineChartLabels: Array<any> = [];
     public lineChartOptions: any = {


### PR DESCRIPTION
Fixes #63

Setting the colors of the pie chart is not well documented. I've found the syntax in this issue: https://github.com/valor-software/ng2-charts/issues/251#issuecomment-225581645